### PR TITLE
Feat/first class methods

### DIFF
--- a/src/FixedArray.php
+++ b/src/FixedArray.php
@@ -95,6 +95,36 @@ class FixedArray
     }
 
     /**
+     * Apply a callback to each item in the array without modifying the original array.
+     *
+     * @param \SplFixedArray $array
+     * @param callable $callback
+     * @return \SplFixedArray
+     */
+    public static function each(SplFixedArray $array, callable $callback): SplFixedArray
+    {
+        foreach ($array as $key => $value) {
+            $callback($value, $key);
+        }
+
+        return $array;
+    }
+
+    /**
+     * Apply a filter to a given fixed array.
+     *
+     * @param \SplFixedArray $array
+     * @param callable $callback
+     * @return \SplFixedArray
+     */
+    public static function filter(SplFixedArray $array, callable $callback): SplFixedArray
+    {
+        $result = array_filter(self::toArray($array), $callback);
+
+        return self::fromArray($result);
+    }
+
+    /**
      * Returns the first value from a fixed array.
      *
      * @param \SplFixedArray $array
@@ -176,6 +206,20 @@ class FixedArray
     public static function last(SplFixedArray $array): mixed
     {
         return self::offsetGet(self::count($array) - 1, $array);
+    }
+
+    /**
+     * Apply a callback to each item in the array and return the new array.
+     *
+     * @param \SplFixedArray $array
+     * @param callable|string $callback
+     * @return \SplFixedArray
+     */
+    public static function map(SplFixedArray $array, callable|string $callback): SplFixedArray
+    {
+        $array = array_map($callback, self::toArray($array));
+
+        return self::fromArray($array);
     }
 
     /**

--- a/src/FixedArray.php
+++ b/src/FixedArray.php
@@ -341,7 +341,7 @@ class FixedArray
      * @param \SplFixedArray $array
      * @return bool
      */
-    public function resize(int $size, SplFixedArray $array): bool
+    public static function resize(int $size, SplFixedArray $array): bool
     {
         return self::setSize($size, $array);
     }

--- a/tests/ArrayMethodTest.php
+++ b/tests/ArrayMethodTest.php
@@ -63,18 +63,18 @@ test('each applies a callback over each item without modifying the array', funct
 });
 
 test('filter removes items from an array that pass a given test', function () {
-   $values = FixedArray::fromArray([1, 2, 3, 4, 5]);
+    $values = FixedArray::fromArray([1, 2, 3, 4, 5]);
 
-   $filtered = FixedArray::filter($values, static fn (int $value) => $value % 2 === 0);
-
-    /** @phpstan-ignore-next-line */
-   $this->assertNotContains(1, $filtered);
+    $filtered = FixedArray::filter($values, static fn (int $value) => $value % 2 === 0);
 
     /** @phpstan-ignore-next-line */
-   $this->assertNotContains(3, $filtered);
+    $this->assertNotContains(1, $filtered);
 
     /** @phpstan-ignore-next-line */
-   $this->assertNotContains(5, $filtered);
+    $this->assertNotContains(3, $filtered);
+
+    /** @phpstan-ignore-next-line */
+    $this->assertNotContains(5, $filtered);
 });
 
 test('first returns the first element of the array', function () {
@@ -118,14 +118,14 @@ test('last retrieves the last value from an array', function () {
 });
 
 test('map applies a function to an array and returns it', function () {
-   $array = FixedArray::fromArray([1, 2, 3, 4, 5]);
+    $array = FixedArray::fromArray([1, 2, 3, 4, 5]);
 
-   $mappedArray = FixedArray::map($array, static fn (int $item) => $item * 2);
+    $mappedArray = FixedArray::map($array, static fn (int $item) => $item * 2);
 
-   foreach ($mappedArray as $index => $item) {
-       /** @phpstan-ignore-next-line */
-       $this->assertEquals($array[$index] * 2, $item);
-   }
+    foreach ($mappedArray as $index => $item) {
+        /** @phpstan-ignore-next-line */
+        $this->assertEquals($array[$index] * 2, $item);
+    }
 });
 
 test('map applies a function by name to an array and returns it', function () {
@@ -134,9 +134,9 @@ test('map applies a function by name to an array and returns it', function () {
     $mappedArray = FixedArray::map($array, 'is_integer');
 
     foreach ($mappedArray as $item) {
-       /** @phpstan-ignore-next-line */
-       $this->assertTrue($item);
-   }
+        /** @phpstan-ignore-next-line */
+        $this->assertTrue($item);
+    }
 });
 
 test('merge will merge together multiple array-like items into a single fixed array', function () {

--- a/tests/ArrayMethodTest.php
+++ b/tests/ArrayMethodTest.php
@@ -44,6 +44,39 @@ test('create returns a new spl fixed array of a given size', function () {
     $this->assertEquals($count, FixedArray::count($array));
 });
 
+test('each applies a callback over each item without modifying the array', function () {
+    $values = FixedArray::fromArray([1, 2, 3]);
+    $otherContainer = FixedArray::create();
+
+    FixedArray::each($values, static function (int $value) use (&$otherContainer) {
+        FixedArray::push($value * 2, $otherContainer);
+    });
+
+    /** @phpstan-ignore-next-line */
+    $this->assertNotEquals($values, $otherContainer);
+
+    /** @phpstan-ignore-next-line */
+    $this->assertEquals(FixedArray::first($values), 1);
+
+    /** @phpstan-ignore-next-line */
+    $this->assertEquals(FixedArray::first($otherContainer), 2);
+});
+
+test('filter removes items from an array that pass a given test', function () {
+   $values = FixedArray::fromArray([1, 2, 3, 4, 5]);
+
+   $filtered = FixedArray::filter($values, static fn (int $value) => $value % 2 === 0);
+
+    /** @phpstan-ignore-next-line */
+   $this->assertNotContains(1, $filtered);
+
+    /** @phpstan-ignore-next-line */
+   $this->assertNotContains(3, $filtered);
+
+    /** @phpstan-ignore-next-line */
+   $this->assertNotContains(5, $filtered);
+});
+
 test('first returns the first element of the array', function () {
     $array = new SplFixedArray(2);
     $test = 'test';
@@ -82,6 +115,28 @@ test('last retrieves the last value from an array', function () {
 
     /** @phpstan-ignore-next-line */
     $this->assertEquals(5, FixedArray::last($array));
+});
+
+test('map applies a function to an array and returns it', function () {
+   $array = FixedArray::fromArray([1, 2, 3, 4, 5]);
+
+   $mappedArray = FixedArray::map($array, static fn (int $item) => $item * 2);
+
+   foreach ($mappedArray as $index => $item) {
+       /** @phpstan-ignore-next-line */
+       $this->assertEquals($array[$index] * 2, $item);
+   }
+});
+
+test('map applies a function by name to an array and returns it', function () {
+    $array = FixedArray::fromArray([1, 2, 3, 4, 5]);
+
+    $mappedArray = FixedArray::map($array, 'is_integer');
+
+    foreach ($mappedArray as $item) {
+       /** @phpstan-ignore-next-line */
+       $this->assertTrue($item);
+   }
 });
 
 test('merge will merge together multiple array-like items into a single fixed array', function () {


### PR DESCRIPTION
For now, these methods use underlying standard array functionality. Not ideal, but just for now.

Additionally, a bugfix for the resize alias method.